### PR TITLE
feat: add CLI parity foundation for env/alias/bootstrap + strict sync parsing

### DIFF
--- a/docs/tasks/01-foundation-alias-env-option-parsing.md
+++ b/docs/tasks/01-foundation-alias-env-option-parsing.md
@@ -1,0 +1,34 @@
+# Task 01: Foundation (Alias, Saved Env, Strict Option Parsing)
+
+Status: `done`
+
+Objective:
+- Align command bootstrap behavior with C for alias expansion, saved environment loading, and strict option parsing.
+
+Source-of-truth references:
+- `lastpass-cli/lpass.c` (alias expansion and `env` loading)
+- `lastpass-cli/cmd.c` (`parse_sync_string`, `parse_color_mode_string`, `parse_bool_arg_string`)
+
+Scope:
+- Load config `env` and inject environment variables before command dispatch.
+- Expand command aliases from `alias.<command>` before dispatch.
+- Introduce shared parsing helpers for `--sync`, `--color`, and C-style boolean args.
+- Remove permissive parsing paths that currently accept malformed values.
+
+Out of scope:
+- New command features (`show --attach`, `share`, `passwd`) handled in later tasks.
+
+Dependencies:
+- None
+
+Implementation steps:
+1. Add bootstrap layer to CLI entry path to load `env` config and expand aliases.
+2. Add reusable argument parsing helpers in Rust command core.
+3. Update command modules to use shared helpers and reject invalid values uniformly.
+4. Add regression tests for alias expansion, env loading, and option parsing errors.
+
+Acceptance criteria:
+- `alias.<name>` config behavior matches C for token expansion.
+- `env` config lines are loaded similarly to C and bad lines are handled safely.
+- Commands reject invalid `--sync`, `--color`, and boolean strings consistently.
+- Existing tests and new tests pass.

--- a/docs/tasks/02-blob-sync-and-shares-data-model.md
+++ b/docs/tasks/02-blob-sync-and-shares-data-model.md
@@ -1,0 +1,35 @@
+# Task 02: Blob Sync Semantics and Share-Aware Data Model
+
+Status: `todo`
+
+Objective:
+- Implement C-like blob loading semantics (`--sync` and auto-sync TTL) and extend the model to represent shares/read-only metadata needed for parity.
+
+Source-of-truth references:
+- `lastpass-cli/blob.c` (`blob_load`, `auto_sync_time`)
+- `lastpass-cli/blob.h` (`share`, readonly flags, share list in blob)
+
+Scope:
+- Refactor blob loading to take explicit sync mode (`auto|now|no`) and honor it.
+- Implement `LPASS_AUTO_SYNC_TIME` freshness window behavior.
+- Extend Rust blob parsing/storage structures to carry share metadata used by commands.
+- Wire share metadata into command read/write paths where needed.
+
+Out of scope:
+- Full `share` command implementation (Task 07).
+
+Dependencies:
+- Task 01
+
+Implementation steps:
+1. Change `load_blob` API to accept sync mode.
+2. Add TTL-based auto-sync behavior equivalent to C.
+3. Add share metadata in blob structs and parser outputs.
+4. Update affected commands to use share-aware data and sync-aware loading.
+5. Add unit/integration tests for sync mode and share parsing behavior.
+
+Acceptance criteria:
+- Commands respect `--sync=auto|now|no` as C does.
+- `LPASS_AUTO_SYNC_TIME` controls cache freshness in auto mode.
+- Share/read-only metadata is available to command logic.
+- Tests cover sync and share model paths.

--- a/docs/tasks/03-show-command-parity.md
+++ b/docs/tasks/03-show-command-parity.md
@@ -1,0 +1,36 @@
+# Task 03: `show` Command Full Parity
+
+Status: `todo`
+
+Objective:
+- Close remaining `show` gaps: regex/fixed searches, multi-match behavior, clipboard, attachments, and strict flag behavior.
+
+Source-of-truth references:
+- `lastpass-cli/cmd-show.c`
+- `lastpass-cli/cmd.c` matching helpers
+
+Scope:
+- Implement `--basic-regexp/-G` and `--fixed-strings/-F` search modes.
+- Implement C-like multi-match handling and `--expand-multi/-x`.
+- Implement `--clip` output-to-clipboard flow.
+- Implement `--attach` handling and related `--quiet` behavior.
+- Preserve current JSON and formatting behaviors where already compatible.
+
+Out of scope:
+- Clipboard env implementation details beyond what `show` needs (Task 08 deep parity).
+
+Dependencies:
+- Task 01
+- Task 02
+
+Implementation steps:
+1. Rework matching pipeline to support exact/regex/fixed modes.
+2. Implement C-like multi-match output and exit behavior.
+3. Add attachment lookup/output path with quiet flag behavior.
+4. Add clipboard output path for selected values.
+5. Add dedicated parity tests for each option combination.
+
+Acceptance criteria:
+- `show` options and outputs match C for implemented paths.
+- `show` no longer silently ignores parity-critical flags.
+- New tests cover regex/fixed, multi-match, clip, and attach cases.

--- a/docs/tasks/04-generate-command-parity.md
+++ b/docs/tasks/04-generate-command-parity.md
@@ -1,0 +1,34 @@
+# Task 04: `generate` Command Full Parity
+
+Status: `todo`
+
+Objective:
+- Bring `generate` to C parity for charset behavior, clipboard support, readonly checks, and update semantics.
+
+Source-of-truth references:
+- `lastpass-cli/cmd-generate.c`
+
+Scope:
+- Implement correct default charset and `--no-symbols` behavior.
+- Implement `--clip/-c` behavior.
+- Enforce readonly shared-entry restrictions consistently with C.
+- Ensure create/update flows match C-side semantics closely.
+
+Out of scope:
+- Broad clipboard env compatibility work (Task 08).
+
+Dependencies:
+- Task 01
+- Task 02
+
+Implementation steps:
+1. Replace current password generator with C-equivalent charset selection.
+2. Add clipboard path for generated password output.
+3. Add readonly guard logic for shared entries.
+4. Align update/create mutation flow with parity expectations.
+5. Add tests for option behavior, edge cases, and readonly failures.
+
+Acceptance criteria:
+- `generate` output length and symbol policy match C.
+- `--clip` path works and is tested.
+- Readonly shared entries are rejected with parity-compatible behavior.

--- a/docs/tasks/05-sync-import-export-parity.md
+++ b/docs/tasks/05-sync-import-export-parity.md
@@ -1,0 +1,34 @@
+# Task 05: `sync`, `import`, `export` Parity
+
+Status: `todo`
+
+Objective:
+- Align `sync`, `import`, and `export` behavior with C client semantics, including protected-entry flows and queue/server behavior.
+
+Source-of-truth references:
+- `lastpass-cli/cmd-sync.c`
+- `lastpass-cli/cmd-import.c`
+- `lastpass-cli/cmd-export.c`
+
+Scope:
+- `sync`: match background/non-background behavior and queue semantics.
+- `import`: align with C-side upload flow and option handling.
+- `export`: parity for field behavior and protected-entry authentication flow.
+- Normalize edge-case output formatting differences where parity requires.
+
+Out of scope:
+- `passwd` and `share` command implementation (Tasks 06 and 07).
+
+Dependencies:
+- Task 01
+- Task 02
+
+Implementation steps:
+1. Rework `sync` to follow C execution model for queue/background behavior.
+2. Rework `import` pipeline to match C upload-oriented behavior.
+3. Add protected-entry reprompt/auth handling to `export`.
+4. Add tests for sync background mode, import upload path, and export protected entries.
+
+Acceptance criteria:
+- `sync`, `import`, and `export` user-visible behavior is C-compatible for supported paths.
+- Relevant parity tests and integration tests pass.

--- a/docs/tasks/06-passwd-command-parity.md
+++ b/docs/tasks/06-passwd-command-parity.md
@@ -1,0 +1,34 @@
+# Task 06: Implement `passwd` Command
+
+Status: `todo`
+
+Objective:
+- Implement `passwd` in Rust with behavior equivalent to C, including re-encryption progress, server interaction, and forced logout.
+
+Source-of-truth references:
+- `lastpass-cli/cmd-passwd.c`
+- related endpoint and crypto flows in `lastpass-cli/`
+
+Scope:
+- Master password change flow with current-password verification.
+- New password validation and confirmation flow.
+- Re-encryption and upload sequence.
+- Session termination on success.
+
+Out of scope:
+- `share` command family (Task 07).
+
+Dependencies:
+- Task 01
+- Task 02
+
+Implementation steps:
+1. Implement command parser and interactive prompt flow.
+2. Implement re-encryption workflow and required API wiring.
+3. Implement success/failure messaging and logout behavior.
+4. Add command tests for success path and major failure conditions.
+
+Acceptance criteria:
+- `lpass passwd` is no longer stubbed.
+- Behavior and output structure match C for major paths.
+- Unit/integration tests cover prompt and API error paths.

--- a/docs/tasks/07-share-command-parity.md
+++ b/docs/tasks/07-share-command-parity.md
@@ -1,0 +1,33 @@
+# Task 07: Implement `share` Command Family
+
+Status: `todo`
+
+Objective:
+- Implement `share` subcommands with strict parity to C behavior, options, and output formats.
+
+Source-of-truth references:
+- `lastpass-cli/cmd-share.c`
+
+Scope:
+- Subcommands: `userls`, `useradd`, `usermod`, `userdel`, `create`, `rm`, `limit`.
+- Shared option parsing (`--sync`, `--color`, permission flags, list mode flags).
+- Share lookup and error behavior.
+- Display and mutation behavior parity for user and limits operations.
+
+Out of scope:
+- Generic environment parity not directly needed by share path (Task 08).
+
+Dependencies:
+- Task 01
+- Task 02
+
+Implementation steps:
+1. Add command module and wire dispatch.
+2. Implement shared parser and subcommand routing.
+3. Implement each subcommand path and server interactions.
+4. Add parity tests for parsing, usage errors, and representative success paths.
+
+Acceptance criteria:
+- `lpass share` is no longer stubbed.
+- Help/usage and subcommand behavior match C conventions.
+- Automated tests cover option matrix and common operations.

--- a/docs/tasks/08-env-prompt-clipboard-logging-parity.md
+++ b/docs/tasks/08-env-prompt-clipboard-logging-parity.md
@@ -1,0 +1,38 @@
+# Task 08: Environment, Prompt, Clipboard, and Logging Parity
+
+Status: `todo`
+
+Objective:
+- Match C handling for environment-driven prompt, clipboard, logging, and tempdir behavior.
+
+Source-of-truth references:
+- `lastpass-cli/password.c`
+- `lastpass-cli/clipboard.c`
+- `lastpass-cli/log.c`
+- `lastpass-cli/edit.c`
+
+Scope:
+- Prompt stack parity for `LPASS_PINENTRY`, `LPASS_DISABLE_PINENTRY`, and related TTY env use.
+- Clipboard command parity for `LPASS_CLIPBOARD_COMMAND` and shell execution behavior.
+- Logging parity for `LPASS_LOG_LEVEL` and log file path behavior.
+- Tempdir/security env behavior needed by editor workflows (`SECURE_TMPDIR`, `TMPDIR`).
+
+Out of scope:
+- Large new UX not present in C client.
+
+Dependencies:
+- Task 01
+- Task 03
+- Task 04
+
+Implementation steps:
+1. Extend password prompting to include pinentry/fallback path parity.
+2. Implement clipboard command/env behavior used by show/generate.
+3. Add log-level-driven logging compatibility paths.
+4. Add tempdir env handling used by editor paths.
+5. Add tests for env-driven branch behavior.
+
+Acceptance criteria:
+- Env vars documented in parity audit are implemented or intentionally documented as deviations.
+- `show --clip` and `generate --clip` use parity-compatible clipboard handling.
+- Prompt and fallback behavior follows C precedence rules.

--- a/docs/tasks/09-parity-tests-and-gates.md
+++ b/docs/tasks/09-parity-tests-and-gates.md
@@ -1,0 +1,33 @@
+# Task 09: Parity Test Expansion and Merge Gates
+
+Status: `todo`
+
+Objective:
+- Ensure parity work remains stable over time with explicit tests and release gates.
+
+Source-of-truth references:
+- Rust tests under `tests/`
+- upstream shell tests under `lastpass-cli/test/`
+
+Scope:
+- Add parity-focused tests for all newly implemented command paths.
+- Expand shell-based compatibility coverage where current upstream tests do not cover new behavior.
+- Define merge gate checks for parity-sensitive changes.
+
+Out of scope:
+- Feature implementation itself (covered by tasks 01-08).
+
+Dependencies:
+- Tasks 01-08
+
+Implementation steps:
+1. Add test cases for new options/behaviors introduced in each task.
+2. Add/adjust upstream shell test wrappers for newly covered commands.
+3. Enforce documented gate commands in CI and local workflow notes.
+
+Acceptance criteria:
+- All parity tasks have direct automated test coverage.
+- Required gate commands are green:
+  - `cargo test`
+  - `./scripts/run-upstream-shell-tests.sh`
+- Coverage remains at or above 80%.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,27 @@
+# LastPass Rust Parity Task Board
+
+Status legend:
+- `todo`: not started
+- `in_progress`: actively being implemented
+- `blocked`: waiting on a dependency
+- `done`: merged with tests passing
+
+Execution order:
+1. `01-foundation-alias-env-option-parsing.md` (`todo`)
+2. `02-blob-sync-and-shares-data-model.md` (`todo`)
+3. `03-show-command-parity.md` (`todo`)
+4. `04-generate-command-parity.md` (`todo`)
+5. `05-sync-import-export-parity.md` (`todo`)
+6. `06-passwd-command-parity.md` (`todo`)
+7. `07-share-command-parity.md` (`todo`)
+8. `08-env-prompt-clipboard-logging-parity.md` (`todo`)
+9. `09-parity-tests-and-gates.md` (`todo`)
+
+Global rules for every task:
+- Match behavior and options from `lastpass-cli/` exactly unless explicitly documented.
+- Keep changes incremental and testable.
+- Add or update tests in the same change.
+- Keep project coverage at or above 80%.
+- Run:
+  - `cargo test`
+  - `./scripts/run-upstream-shell-tests.sh`

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -189,7 +189,7 @@ fn agent_start(key: &[u8; KDF_HASH_LEN]) -> Result<()> {
     if config_exists("plaintext_key") {
         return Ok(());
     }
-    if env::var("LPASS_AGENT_DISABLE").as_deref() == Ok("1") {
+    if crate::lpenv::var("LPASS_AGENT_DISABLE").as_deref() == Ok("1") {
         return Ok(());
     }
 
@@ -272,7 +272,7 @@ fn agent_socket_path() -> Result<PathBuf> {
 }
 
 fn agent_timeout() -> Option<Duration> {
-    let value = env::var("LPASS_AGENT_TIMEOUT")
+    let value = crate::lpenv::var("LPASS_AGENT_TIMEOUT")
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(60 * 60);

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::process::Command;
@@ -315,11 +314,11 @@ fn edit_with_editor(initial: &str) -> Result<String, String> {
         .map_err(|err| format!("write: {err}"))?;
     file.flush().map_err(|err| format!("flush: {err}"))?;
 
-    let editor = env::var("VISUAL")
+    let editor = crate::lpenv::var("VISUAL")
         .ok()
         .filter(|value| !value.trim().is_empty())
         .or_else(|| {
-            env::var("EDITOR")
+            crate::lpenv::var("EDITOR")
                 .ok()
                 .filter(|value| !value.trim().is_empty())
         })
@@ -883,16 +882,28 @@ mod tests {
         let any = make_editor_initial_text(&base);
         assert!(any.contains("Name: entry"));
 
-        let username = make_editor_initial_text(&AddArgs { choice: EditChoice::Username, ..base.clone() });
+        let username = make_editor_initial_text(&AddArgs {
+            choice: EditChoice::Username,
+            ..base.clone()
+        });
         assert!(username.ends_with('\n'));
 
-        let password = make_editor_initial_text(&AddArgs { choice: EditChoice::Password, ..base.clone() });
+        let password = make_editor_initial_text(&AddArgs {
+            choice: EditChoice::Password,
+            ..base.clone()
+        });
         assert!(password.ends_with('\n'));
 
-        let url = make_editor_initial_text(&AddArgs { choice: EditChoice::Url, ..base.clone() });
+        let url = make_editor_initial_text(&AddArgs {
+            choice: EditChoice::Url,
+            ..base.clone()
+        });
         assert!(url.ends_with('\n'));
 
-        let notes = make_editor_initial_text(&AddArgs { choice: EditChoice::Notes, ..base.clone() });
+        let notes = make_editor_initial_text(&AddArgs {
+            choice: EditChoice::Notes,
+            ..base.clone()
+        });
         assert!(notes.ends_with('\n'));
 
         let field = make_editor_initial_text(&AddArgs {
@@ -928,13 +939,8 @@ mod tests {
     fn apply_choice_value_updates_existing_field() {
         let mut account = new_account("entry", EditChoice::Any, NoteType::SshKey, false);
         account.fields.push(make_field("Hostname", "old"));
-        apply_choice_value(
-            &mut account,
-            EditChoice::Field,
-            Some("Hostname"),
-            "new",
-        )
-        .expect("update");
+        apply_choice_value(&mut account, EditChoice::Field, Some("Hostname"), "new")
+            .expect("update");
         let field = account
             .fields
             .iter()

--- a/src/commands/argparse.rs
+++ b/src/commands/argparse.rs
@@ -1,0 +1,80 @@
+#![forbid(unsafe_code)]
+
+use std::iter::Peekable;
+use std::slice::Iter;
+
+use crate::commands::data::SyncMode;
+
+pub(crate) fn parse_sync_option(
+    arg: &str,
+    iter: &mut Peekable<Iter<'_, String>>,
+    usage: &str,
+) -> Result<Option<SyncMode>, String> {
+    if let Some(value) = arg.strip_prefix("--sync=") {
+        let mode = SyncMode::parse(value).ok_or_else(|| usage.to_string())?;
+        return Ok(Some(mode));
+    }
+
+    if arg == "--sync" {
+        let value = iter.next().ok_or_else(|| usage.to_string())?;
+        let mode = SyncMode::parse(value).ok_or_else(|| usage.to_string())?;
+        return Ok(Some(mode));
+    }
+
+    Ok(None)
+}
+
+#[allow(dead_code)]
+pub(crate) fn parse_bool_arg_string(extra: Option<&str>) -> bool {
+    match extra {
+        None => true,
+        Some(value) => value == "true",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sync_option_supports_equals_and_separate_values() {
+        let usage = "usage";
+
+        let arg = "--sync=NOW".to_string();
+        let args = [arg];
+        let mut iter = args.iter().peekable();
+        let parsed = parse_sync_option(args[0].as_str(), &mut iter, usage).expect("parse");
+        assert_eq!(parsed, Some(SyncMode::Now));
+
+        let args = ["--sync".to_string(), "no".to_string()];
+        let mut iter = args.iter().peekable();
+        let first = iter.next().expect("first");
+        let parsed = parse_sync_option(first, &mut iter, usage).expect("parse");
+        assert_eq!(parsed, Some(SyncMode::No));
+    }
+
+    #[test]
+    fn parse_sync_option_rejects_invalid_or_missing_values() {
+        let usage = "usage";
+
+        let arg = "--sync=invalid".to_string();
+        let args = [arg];
+        let mut iter = args.iter().peekable();
+        let err = parse_sync_option(args[0].as_str(), &mut iter, usage).expect_err("must fail");
+        assert_eq!(err, "usage");
+
+        let args = ["--sync".to_string()];
+        let mut iter = args.iter().peekable();
+        let first = iter.next().expect("first");
+        let err = parse_sync_option(first, &mut iter, usage).expect_err("must fail");
+        assert_eq!(err, "usage");
+    }
+
+    #[test]
+    fn parse_bool_arg_string_matches_c_behavior() {
+        assert!(parse_bool_arg_string(None));
+        assert!(parse_bool_arg_string(Some("true")));
+        assert!(!parse_bool_arg_string(Some("false")));
+        assert!(!parse_bool_arg_string(Some("anything")));
+    }
+}

--- a/src/commands/duplicate.rs
+++ b/src/commands/duplicate.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 use crate::blob::Blob;
+use crate::commands::argparse::parse_sync_option;
 use crate::commands::data::{load_blob, save_blob};
 use crate::terminal;
 
@@ -25,11 +26,7 @@ fn run_inner(args: &[String]) -> Result<i32, String> {
             name = Some(arg.clone());
             continue;
         }
-        if arg.starts_with("--sync=") {
-            continue;
-        }
-        if arg == "--sync" {
-            let _ = iter.next();
+        if parse_sync_option(arg, &mut iter, usage)?.is_some() {
             continue;
         }
         if arg == "--color" {
@@ -185,6 +182,12 @@ mod tests {
     #[test]
     fn run_inner_rejects_invalid_color_mode() {
         let err = run_inner(&["--color=rainbow".to_string()]).expect_err("bad color");
+        assert!(err.contains("usage: duplicate"));
+
+        let err = run_inner(&["--sync".to_string()]).expect_err("missing sync value");
+        assert!(err.contains("usage: duplicate"));
+
+        let err = run_inner(&["--sync=bad".to_string(), "x".to_string()]).expect_err("bad sync");
         assert!(err.contains("usage: duplicate"));
     }
 }

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::process::Command;
@@ -342,11 +341,11 @@ fn edit_with_editor(initial: &str) -> Result<String, String> {
         .map_err(|err| format!("write: {err}"))?;
     file.flush().map_err(|err| format!("flush: {err}"))?;
 
-    let editor = env::var("VISUAL")
+    let editor = crate::lpenv::var("VISUAL")
         .ok()
         .filter(|value| !value.trim().is_empty())
         .or_else(|| {
-            env::var("EDITOR")
+            crate::lpenv::var("EDITOR")
                 .ok()
                 .filter(|value| !value.trim().is_empty())
         })
@@ -888,10 +887,12 @@ mod tests {
     fn parse_update_input_tracks_unknown_fields_and_reprompt() {
         let parsed = parse_update_input("Custom: value\nReprompt: no", NoteType::None);
         assert_eq!(parsed.reprompt, Some(false));
-        assert!(parsed
-            .fields
-            .iter()
-            .any(|(name, value)| name == "Custom" && value == "value"));
+        assert!(
+            parsed
+                .fields
+                .iter()
+                .any(|(name, value)| name == "Custom" && value == "value")
+        );
     }
 
     #[test]

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 
-use std::env;
 use std::io::{self, BufRead, Write};
 
 use super::data::ensure_mock_blob;
@@ -305,7 +304,7 @@ fn persist_blob_after_login(
     session: &Session,
     key: &[u8; KDF_HASH_LEN],
 ) -> std::result::Result<(), String> {
-    let use_mock = env::var("LPASS_HTTP_MOCK").as_deref() == Ok("1");
+    let use_mock = crate::lpenv::var("LPASS_HTTP_MOCK").as_deref() == Ok("1");
     let store = ConfigStore::from_current();
     persist_blob_after_login_with_fetch(&store, use_mock, session, key, fetch_blob)
 }
@@ -418,8 +417,8 @@ fn calculate_trust_id_with_store(store: &ConfigStore, force: bool) -> Result<Opt
 fn calculate_trust_label() -> std::result::Result<String, String> {
     #[cfg(unix)]
     {
-        let uts = nix::sys::utsname::uname()
-            .map_err(|_| "Failed to determine uname.".to_string())?;
+        let uts =
+            nix::sys::utsname::uname().map_err(|_| "Failed to determine uname.".to_string())?;
         let nodename = uts.nodename().to_string_lossy();
         let sysname = uts.sysname().to_string_lossy();
         let release = uts.release().to_string_lossy();
@@ -428,11 +427,12 @@ fn calculate_trust_label() -> std::result::Result<String, String> {
 
     #[cfg(not(unix))]
     {
-        let hostname = env::var("HOSTNAME")
-            .or_else(|_| env::var("COMPUTERNAME"))
+        let hostname = crate::lpenv::var("HOSTNAME")
+            .or_else(|_| crate::lpenv::var("COMPUTERNAME"))
             .unwrap_or_else(|_| "unknown-host".to_string());
-        let sysname = env::var("OS").unwrap_or_else(|_| "UnknownOS".to_string());
-        let release = env::var("OS_VERSION").unwrap_or_else(|_| "unknown-release".to_string());
+        let sysname = crate::lpenv::var("OS").unwrap_or_else(|_| "UnknownOS".to_string());
+        let release =
+            crate::lpenv::var("OS_VERSION").unwrap_or_else(|_| "unknown-release".to_string());
         Ok(format!("{hostname} - {sysname} {release}"))
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod add;
+mod argparse;
 mod data;
 mod duplicate;
 mod edit;

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -187,12 +187,8 @@ mod tests {
         let err = run_inner(&["--sync".to_string()]).expect_err("missing sync value");
         assert!(err.contains("usage: rm"));
 
-        let err = run_inner(&[
-            "--sync".to_string(),
-            "bad".to_string(),
-            "alpha".to_string(),
-        ])
-        .expect_err("bad sync value with separate arg");
+        let err = run_inner(&["--sync".to_string(), "bad".to_string(), "alpha".to_string()])
+            .expect_err("bad sync value with separate arg");
         assert!(err.contains("usage: rm"));
 
         let err = run_inner(&["--sync=bad".to_string(), "alpha".to_string()])

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 use crate::blob::Account;
+use crate::commands::argparse::parse_sync_option;
 use crate::commands::data::load_blob;
 use crate::format::{format_account, format_field};
 use crate::notes::expand_notes;
@@ -75,10 +76,8 @@ fn run_inner(args: &[String]) -> Result<i32, String> {
             title_format_override = Some(value.to_string());
         } else if let Some(value) = arg.strip_prefix("--title-format=") {
             title_format_override = Some(value.to_string());
-        } else if arg.starts_with("--sync=") {
-            // ignored
-        } else if arg == "--sync" || arg == "-S" {
-            let _ = iter.next();
+        } else if parse_sync_option(arg, &mut iter, usage)?.is_some() {
+            // parsed and ignored for now
         } else if arg == "--all" || arg == "-A" {
             choice = ShowChoice::All;
         } else if arg == "--basic-regexp" || arg == "-G" {
@@ -403,6 +402,8 @@ mod tests {
     fn run_inner_rejects_invalid_invocations() {
         assert!(run_inner(&[]).is_err());
         assert!(run_inner(&["--bogus".to_string()]).is_err());
+        assert!(run_inner(&["--sync".to_string()]).is_err());
+        assert!(run_inner(&["--sync=bad".to_string(), "x".to_string()]).is_err());
         assert!(run_inner(&["--field".to_string()]).is_err());
         assert!(run_inner(&["--format".to_string()]).is_err());
         assert!(run_inner(&["--title-format".to_string()]).is_err());

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,7 +1,5 @@
 #![forbid(unsafe_code)]
 
-use std::env;
-
 use crate::agent::agent_get_decryption_key;
 use crate::commands::data::ensure_mock_blob;
 use crate::config::ConfigStore;
@@ -24,7 +22,7 @@ pub fn run(args: &[String]) -> i32 {
 fn run_inner(args: &[String]) -> Result<i32, String> {
     let parsed = parse_args(args)?;
 
-    if env::var("LPASS_HTTP_MOCK").as_deref() == Ok("1") {
+    if crate::lpenv::var("LPASS_HTTP_MOCK").as_deref() == Ok("1") {
         ensure_mock_blob().map_err(|err| format!("{err}"))?;
         let _ = parsed.background;
         return Ok(0);

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,6 @@
 #![forbid(unsafe_code)]
 
 use std::collections::HashMap;
-use std::env;
 
 use reqwest::blocking::Client;
 use reqwest::header::{COOKIE, USER_AGENT};
@@ -35,7 +34,7 @@ pub struct HttpClient {
 
 impl HttpClient {
     pub fn from_env() -> Result<Self> {
-        if env::var("LPASS_HTTP_MOCK").as_deref() == Ok("1") {
+        if crate::lpenv::var("LPASS_HTTP_MOCK").as_deref() == Ok("1") {
             Ok(Self::mock())
         } else {
             Self::real()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod format;
 pub mod http;
 pub mod kdf;
+pub mod lpenv;
 pub mod notes;
 pub mod password;
 pub mod session;

--- a/src/lpenv.rs
+++ b/src/lpenv.rs
@@ -1,0 +1,128 @@
+#![forbid(unsafe_code)]
+
+use std::collections::HashMap;
+use std::env::VarError;
+use std::ffi::{OsStr, OsString};
+use std::sync::{OnceLock, RwLock};
+
+use crate::config::config_read_string;
+
+static OVERRIDES: OnceLock<RwLock<HashMap<OsString, OsString>>> = OnceLock::new();
+
+fn overrides() -> &'static RwLock<HashMap<OsString, OsString>> {
+    OVERRIDES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn with_read_overrides<T>(f: impl FnOnce(&HashMap<OsString, OsString>) -> T) -> T {
+    match overrides().read() {
+        Ok(guard) => f(&guard),
+        Err(poisoned) => {
+            let guard = poisoned.into_inner();
+            f(&guard)
+        }
+    }
+}
+
+fn with_write_overrides(f: impl FnOnce(&mut HashMap<OsString, OsString>)) {
+    match overrides().write() {
+        Ok(mut guard) => f(&mut guard),
+        Err(poisoned) => {
+            let mut guard = poisoned.into_inner();
+            f(&mut guard);
+        }
+    }
+}
+
+pub fn var_os<K: AsRef<OsStr>>(name: K) -> Option<OsString> {
+    let key = name.as_ref().to_os_string();
+    if let Some(value) = with_read_overrides(|map| map.get(&key).cloned()) {
+        return Some(value);
+    }
+    std::env::var_os(key)
+}
+
+pub fn var(name: &str) -> Result<String, VarError> {
+    match var_os(name) {
+        Some(value) => value.into_string().map_err(VarError::NotUnicode),
+        None => Err(VarError::NotPresent),
+    }
+}
+
+pub fn reload_saved_environment() -> Result<(), String> {
+    with_write_overrides(|map| map.clear());
+
+    let env_value = match config_read_string("env") {
+        Ok(Some(value)) => value,
+        Ok(None) => return Ok(()),
+        Err(err) => return Err(format!("{err}")),
+    };
+
+    let mut entries: Vec<(OsString, OsString)> = Vec::new();
+    for line in env_value.split('\n') {
+        if line.is_empty() {
+            continue;
+        }
+        let Some((name, value)) = line.split_once('=') else {
+            warn_invalid_env_line(line);
+            continue;
+        };
+        if name.is_empty() {
+            warn_invalid_env_line(line);
+            continue;
+        }
+        entries.push((OsString::from(name), OsString::from(value)));
+    }
+
+    with_write_overrides(|map| {
+        for (name, value) in entries {
+            map.insert(name, value);
+        }
+    });
+
+    Ok(())
+}
+
+fn warn_invalid_env_line(line: &str) {
+    eprintln!("warning: The environment line '{line}' is invalid.");
+}
+
+#[cfg(test)]
+pub(crate) fn set_override_for_tests(name: &str, value: &str) {
+    with_write_overrides(|map| {
+        map.insert(OsString::from(name), OsString::from(value));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn clear_overrides_for_tests() {
+    with_write_overrides(|map| map.clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn overlay_var_prefers_saved_values() {
+        clear_overrides_for_tests();
+        set_override_for_tests("LPASS_TEST_ENV", "saved");
+        assert_eq!(var("LPASS_TEST_ENV").as_deref(), Ok("saved"));
+        clear_overrides_for_tests();
+    }
+
+    #[test]
+    fn var_returns_not_present_when_missing() {
+        clear_overrides_for_tests();
+        let err = var("LPASS_MISSING_ENV").expect_err("missing value");
+        assert!(matches!(err, VarError::NotPresent));
+    }
+
+    #[test]
+    fn var_os_returns_override_value() {
+        clear_overrides_for_tests();
+        set_override_for_tests("LPASS_OS_ENV", "value");
+        assert_eq!(var_os("LPASS_OS_ENV"), Some(OsString::from("value")));
+        clear_overrides_for_tests();
+    }
+}

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 
-use std::env;
 use std::process::Command;
 
 use crate::error::{LpassError, Result};
@@ -27,7 +26,7 @@ pub fn prompt_password(username: &str) -> Result<String> {
 }
 
 fn askpass_program_from_env() -> Option<String> {
-    askpass_program_from_value(env::var("LPASS_ASKPASS").ok())
+    askpass_program_from_value(crate::lpenv::var("LPASS_ASKPASS").ok())
 }
 
 fn askpass_program_from_value(value: Option<String>) -> Option<String> {

--- a/tests/logout_compat.rs
+++ b/tests/logout_compat.rs
@@ -2,14 +2,21 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_TEST_HOME_ID: AtomicU64 = AtomicU64::new(0);
 
 fn unique_test_home() -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("time went backwards")
         .as_nanos();
-    std::env::temp_dir().join(format!("lpass-logout-compat-{nanos}"))
+    let seq = NEXT_TEST_HOME_ID.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "lpass-logout-compat-{}-{nanos}-{seq}",
+        std::process::id()
+    ))
 }
 
 fn write_test_file(home: &Path, name: &str) {


### PR DESCRIPTION
  - add saved-environment overlay support (env config) and load it at CLI startup
  - add alias expansion from alias.<command> before command dispatch
  - migrate runtime env reads to shared lpenv wrappers (safe Rust, no process env mutation)
  - add shared --sync parser and enforce strict validation across commands
  - make sync mode parsing case-insensitive to match C behaviour
  - tighten mv/import usage text to include supported --sync
  - require a value for export --fields (reject missing value)
  - add regression tests for:
      - saved env loading in end-to-end CLI flow
      - alias expansion in end-to-end CLI flow - strict sync error paths in command parsers
  - harden logout compatibility test temp-home uniqueness